### PR TITLE
Removed tax calculation and added check if street and city empty

### DIFF
--- a/Model/Carrier/PostNord.php
+++ b/Model/Carrier/PostNord.php
@@ -107,10 +107,10 @@ class PostNord extends AbstractCarrier implements CarrierInterface
 
         $recipient_street_address = $request->getDestStreet();
         $recipient_address_line = explode(PHP_EOL, $recipient_street_address);
-        $recipient_address1 = !empty($recipient_address_line[0]) ? $recipient_address_line[0] : 'Gate 1';
-        $recipient_address2 = !empty($recipient_address_line[1]) ? $recipient_address_line[1] : 'Gate 2';
+        $recipient_address1 = !empty($recipient_address_line[0]) ? $recipient_address_line[0] : 'Street 1';
+        $recipient_address2 = !empty($recipient_address_line[1]) ? $recipient_address_line[1] : 'Street 2';
         $recipient_zip = $request->getDestPostcode();
-        $recipient_city = !empty($request->getDestCity()) ? $request->getDestCity() : 'Stedsnavn';
+        $recipient_city = !empty($request->getDestCity()) ? $request->getDestCity() : 'Cityname';
         $recipient_country_code = $request->getDestCountryId();
         $package_weight = $request->getPackageWeight();
         $sender_address1 = $this->getStoreStreetLine1();

--- a/Model/Carrier/PostNord.php
+++ b/Model/Carrier/PostNord.php
@@ -107,10 +107,10 @@ class PostNord extends AbstractCarrier implements CarrierInterface
 
         $recipient_street_address = $request->getDestStreet();
         $recipient_address_line = explode(PHP_EOL, $recipient_street_address);
-        $recipient_address1 = !empty($recipient_address_line[0]) ? $recipient_address_line[0] : $recipient_street_address;
-        $recipient_address2 = !empty($recipient_address_line[1]) ? $recipient_address_line[1] : '';
+        $recipient_address1 = !empty($recipient_address_line[0]) ? $recipient_address_line[0] : 'Gate 1';
+        $recipient_address2 = !empty($recipient_address_line[1]) ? $recipient_address_line[1] : 'Gate 2';
         $recipient_zip = $request->getDestPostcode();
-        $recipient_city = $request->getDestCity();
+        $recipient_city = !empty($request->getDestCity()) ? $request->getDestCity() : 'Stedsnavn';
         $recipient_country_code = $request->getDestCountryId();
         $package_weight = $request->getPackageWeight();
         $sender_address1 = $this->getStoreStreetLine1();

--- a/Model/Carrier/PostNord.php
+++ b/Model/Carrier/PostNord.php
@@ -401,7 +401,7 @@ class PostNord extends AbstractCarrier implements CarrierInterface
                     foreach ($product->pickupPoints as $pickupPoint) {
                         $products[$product->code.'_'.$pickupPoint->customerId] = [
                             'title' => 'PostNord',
-                            'cost' => $price * 1.25,
+                            'cost' => $price,
                             'code' => $pickupPoint->customerId,
                             'method' => $product->name .': ' .$pickupPoint->name . ' ('. $pickupPoint->customerId . ')'
                         ];
@@ -409,7 +409,7 @@ class PostNord extends AbstractCarrier implements CarrierInterface
                 } else {
                     $products[$product->code] = [
                         'title' => 'PostNord',
-                        'cost' => $price * 1.25,
+                        'cost' => $price,
                         'code' => $product->code,
                         'method' => $product->name
                     ];


### PR DESCRIPTION
Remove tax calculation
Tax calculation should be handled by Magento native tax settings in:
Store -> Configuration -> Sales -> Tax Classes -> Tax Class for Shipping

Added fallback if street or city is empty
Added check if street address line 1 or 2, or city is empty. If empty use hardcoded option.
Shipping price lookup now works in shopping cart where only postode is available.